### PR TITLE
Fix for Xcode 12 Swift 5.3

### DIFF
--- a/Source/Extensions/UIView+Square1.swift
+++ b/Source/Extensions/UIView+Square1.swift
@@ -85,7 +85,8 @@ public extension UIView {
     }
     
     /// IBInspectable shadowColor.
-    @IBInspectable var shadowColor: UIColor {
+    /// Renamed to `inspectableShadowColor` due to Xcode 12 UILabel.shadowColor property.
+    @IBInspectable var inspectableShadowColor: UIColor {
         get {
             guard let color = layer.shadowColor else {
                 return .black
@@ -118,7 +119,7 @@ public extension UIView {
     }
     
     func updateShadow() {
-        layer.shadowColor = shadowColor.cgColor
+        layer.shadowColor = inspectableShadowColor.cgColor
     }
     
     /// IBInspectable shadowOffsetWidth.

--- a/Square1Tools.podspec
+++ b/Square1Tools.podspec
@@ -4,11 +4,11 @@ Pod::Spec.new do |s|
   s.version      = "1.8.0"
   s.summary      = "A collection of tools used in our Swift projects"
   s.description  = "A handy collection of helpers, types and hacks used on our Swift projects"
-  s.homepage     = "https://github.com/square1-io/Square1-iOS-Tools"
+  s.homepage     = "https://https://github.com/krysztalzg/Square1-iOS-Tools"
   s.license      = { :type => "MIT", :file => "LICENSE.md" }
   s.author       = "Square1"
   s.platform     = :ios, "9.0"
-  s.source       = { :git => "https://github.com/square1-io/Square1-iOS-Tools.git", :tag => s.version }
+  s.source       = { :git => "https://https://github.com/krysztalzg/Square1-iOS-Tools.git", :tag => s.version }
   s.source_files  = "Source/**/*.swift"
   s.swift_versions = "5.3"
 end

--- a/Square1Tools.podspec
+++ b/Square1Tools.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
 
   s.name         = "Square1Tools"
-  s.version      = "1.7.0"
+  s.version      = "1.8.0"
   s.summary      = "A collection of tools used in our Swift projects"
   s.description  = "A handy collection of helpers, types and hacks used on our Swift projects"
   s.homepage     = "https://github.com/square1-io/Square1-iOS-Tools"
@@ -10,5 +10,5 @@ Pod::Spec.new do |s|
   s.platform     = :ios, "9.0"
   s.source       = { :git => "https://github.com/square1-io/Square1-iOS-Tools.git", :tag => s.version }
   s.source_files  = "Source/**/*.swift"
-  s.swift_versions = "5.0"
+  s.swift_versions = "5.3"
 end

--- a/Square1Tools.podspec
+++ b/Square1Tools.podspec
@@ -4,11 +4,11 @@ Pod::Spec.new do |s|
   s.version      = "1.8.0"
   s.summary      = "A collection of tools used in our Swift projects"
   s.description  = "A handy collection of helpers, types and hacks used on our Swift projects"
-  s.homepage     = "https://https://github.com/krysztalzg/Square1-iOS-Tools"
+  s.homepage     = "https://github.com/square1-io/Square1-iOS-Tools"
   s.license      = { :type => "MIT", :file => "LICENSE.md" }
   s.author       = "Square1"
   s.platform     = :ios, "9.0"
-  s.source       = { :git => "https://https://github.com/krysztalzg/Square1-iOS-Tools.git", :tag => s.version }
+  s.source       = { :git => "https://github.com/square1-io/Square1-iOS-Tools.git", :tag => s.version }
   s.source_files  = "Source/**/*.swift"
   s.swift_versions = "5.3"
 end


### PR DESCRIPTION
UILabel now has it's own `shadowColor` property, so the extension one had to be renamed to fix overlap.